### PR TITLE
Updates logic for binding to cluster

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -13,7 +13,7 @@ jobs:
   verify:
     if: ${{ !contains( github.event.pull_request.labels.*.name, 'skip ci' ) }}
     runs-on: ubuntu-latest
-    container: ibmgaragecloud/cli-tools:0.4.0-lite
+    container: ibmgaragecloud/cli-tools:0.7.0-lite
 
     strategy:
       matrix:
@@ -30,6 +30,7 @@ jobs:
       TF_VAR_resource_group_name: ${{ secrets.TEST_RESOURCE_GROUP }}
       TF_VAR_region: ${{ secrets.TEST_REGION }}
       TF_VAR_cluster_name: ${{ secrets[format('TEST_CLUSTER_{0}', matrix.platform)] }}
+      TF_VAR_name_prefix: ${{ secrets[format('TEST_CLUSTER_{0}', matrix.platform)] }}
       TF_VAR_cluster_type: ${{ matrix.platform }}
       TF_VAR_vpc_cluster: ${{ endswith(matrix.platform, 'vpc') }}
 
@@ -64,6 +65,7 @@ jobs:
 
       # Destroy
       - name: Destroy ${{ matrix.platform }}
+        if: ${{ always() }}
         run: |
           cd /tmp/workspace
           ./destroy.sh

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "ibm" {
-  version = ">= 1.2.1"
+  version = ">= 1.9.0"
   region  = var.resource_location
 }
 
@@ -21,7 +21,7 @@ locals {
   name        = var.name != "" ? var.name : "${replace(local.name_prefix, "/[^a-zA-Z0-9_\\-\\.]/", "")}-sysdig"
   role        = "Manager"
   provision   = var.provision
-  bind        = (var.provision || (!var.provision && var.name != "")) && var.cluster_id != ""
+  bind        = (var.provision || (!var.provision && var.name != "")) && var.cluster_name != ""
   access_key  = local.bind ? ibm_resource_key.sysdig_instance_key[0].credentials["Sysdig Access Key"] : ""
 }
 
@@ -79,7 +79,7 @@ resource "null_resource" "sysdig_bind" {
 
   triggers = {
     cluster_id  = var.cluster_id
-    instance_id = var.name
+    instance_id = data.ibm_resource_instance.sysdig_instance[0].guid
   }
 
   provisioner "local-exec" {

--- a/scripts/bind-instance.sh
+++ b/scripts/bind-instance.sh
@@ -4,23 +4,23 @@ SCRIPT_DIR=$(cd $(dirname $0); pwd -P)
 MODULE_DIR=$(cd ${SCRIPT_DIR}/..; pwd -P)
 
 CLUSTER_ID="$1"
-INSTANCE_NAME="$2"
+INSTANCE_ID="$2"
 ACCESS_KEY="$3"
 
-echo "Configuring Sysdig for ${CLUSTER_ID} cluster and ${INSTANCE_NAME} Sysdig instance"
+echo "Configuring Sysdig for ${CLUSTER_ID} cluster and ${INSTANCE_ID} Sysdig instance"
 
 ibmcloud target
-if ibmcloud ob monitoring config ls --cluster "${CLUSTER_ID}" | grep -q "Instance name"; then
-  EXISTING_INSTANCE_NAME=$(ibmcloud ob monitoring config ls --cluster "${CLUSTER_ID}" | grep "Instance name" | sed -E "s/Instance name: +([^ ]+)/\1/g")
-  if [[ "${EXISTING_INSTANCE_NAME}" == "${INSTANCE_NAME}" ]]; then
+if ibmcloud ob monitoring config ls --cluster "${CLUSTER_ID}" | grep -q "Instance ID"; then
+  EXISTING_INSTANCE_ID=$(ibmcloud ob monitoring config ls --cluster "${CLUSTER_ID}" | grep "Instance ID" | sed -E "s/Instance ID: +([^ ]+)/\1/g")
+  if [[ "${EXISTING_INSTANCE_ID}" == "${INSTANCE_ID}" ]]; then
     echo "Sysdig configuration already exists on this cluster"
     exit 0
   else
-    echo "Existing Sysdig configuration found on this cluster for a different Sysdig instance: ${EXISTING_INSTANCE_NAME}."
+    echo "Existing Sysdig configuration found on this cluster for a different Sysdig instance: ${EXISTING_INSTANCE_ID}."
     echo "Removing the config before creating the new one"
     ibmcloud ob monitoring config delete \
       --cluster "${CLUSTER_ID}" \
-      --instance "${EXISTING_INSTANCE_NAME}" \
+      --instance "${EXISTING_INSTANCE_ID}" \
       --force
   fi
 else
@@ -30,8 +30,8 @@ fi
 
 set -e
 
-echo "Creating Sysdig configuration for ${CLUSTER_ID} cluster and ${INSTANCE_NAME} Sysdig instance"
+echo "Creating Sysdig configuration for ${CLUSTER_ID} cluster and ${INSTANCE_ID} Sysdig instance"
 ibmcloud ob monitoring config create \
   --cluster "${CLUSTER_ID}" \
-  --instance "${INSTANCE_NAME}" \
+  --instance "${INSTANCE_ID}" \
   --sysdig-access-key "${ACCESS_KEY}"

--- a/scripts/bind-instance.sh
+++ b/scripts/bind-instance.sh
@@ -22,6 +22,8 @@ if ibmcloud ob monitoring config ls --cluster "${CLUSTER_ID}" | grep -q "Instanc
       --cluster "${CLUSTER_ID}" \
       --instance "${EXISTING_INSTANCE_ID}" \
       --force
+
+      sleep 60
   fi
 else
   echo "No existing binding found for cluster ${CLUSTER_ID}"

--- a/scripts/unbind-instance.sh
+++ b/scripts/unbind-instance.sh
@@ -6,7 +6,7 @@ MODULE_DIR=$(cd ${SCRIPT_DIR}/..; pwd -P)
 CLUSTER_ID="$1"
 INSTANCE_ID="$2"
 
-ibmcloud ob logging config delete \
+ibmcloud ob monitoring config delete \
   --cluster "${CLUSTER_ID}" \
   --instance "${INSTANCE_ID}" \
   --force

--- a/test/stages/stage-sysdig.tf
+++ b/test/stages/stage-sysdig.tf
@@ -4,4 +4,10 @@ module "dev_sysdig" {
   resource_group_name      = var.resource_group_name
   resource_location        = var.region
   provision                = true
+  cluster_id               = module.dev_cluster.id
+  cluster_name             = module.dev_cluster.name
+  cluster_type             = module.dev_cluster.type_code
+  cluster_config_file_path = module.dev_cluster.config_file_path
+  tools_namespace          = module.dev_capture_state.namespace
+  name_prefix              = var.name_prefix
 }

--- a/test/stages/stage1-cluster.tf
+++ b/test/stages/stage1-cluster.tf
@@ -1,0 +1,18 @@
+module "dev_cluster" {
+  source = "github.com/ibm-garage-cloud/terraform-ibm-container-platform.git"
+
+  resource_group_name     = var.resource_group_name
+  cluster_name            = var.cluster_name
+  cluster_region          = var.region
+  cluster_type            = substr(var.cluster_type, 0, 3) == "iks" ? "kubernetes" : var.cluster_type
+  cluster_exists          = true
+  ibmcloud_api_key        = var.ibmcloud_api_key
+  name_prefix             = var.name_prefix
+  is_vpc                  = var.vpc_cluster
+  private_vlan_id         = ""
+  public_vlan_id          = ""
+  vlan_datacenter         = ""
+  cluster_machine_type    = ""
+  cluster_worker_count    = 3
+  cluster_hardware        = ""
+}

--- a/test/stages/stage1-namespaces.tf
+++ b/test/stages/stage1-namespaces.tf
@@ -1,0 +1,8 @@
+module "dev_tools_namespace" {
+  source = "github.com/ibm-garage-cloud/terraform-cluster-namespace.git"
+
+  cluster_type             = module.dev_cluster.type_code
+  cluster_config_file_path = module.dev_cluster.config_file_path
+  tls_secret_name          = module.dev_cluster.tls_secret_name
+  name                     = var.tools_namespace
+}

--- a/test/stages/stage1b-capture-state.tf
+++ b/test/stages/stage1b-capture-state.tf
@@ -1,0 +1,8 @@
+module "dev_capture_state" {
+  source = "github.com/ibm-garage-cloud/terraform-k8s-capture-state"
+
+  cluster_type             = module.dev_cluster.type_code
+  cluster_config_file_path = module.dev_cluster.config_file_path
+  namespace                = module.dev_tools_namespace.name
+  output_path              = "${path.cwd}/cluster-state/before"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,12 @@ variable "namespace" {
   default     = "ibm-observe"
 }
 
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster into which the sysdig instance should be bound"
+  default     = ""
+}
+
 variable "cluster_id" {
   type        = string
   description = "The id of the cluster into which the sysdig instance should be bound"


### PR DESCRIPTION
* Uses instance guid instead of instance name for binding to the service
* Introduces cluster_name variable to use for count test
* Sets minimum ibm provider version to v1.9.0 to support guid output

* Updates module testing to include bind to cluster
* Bumps cli-tools version to 0.7.0-lite
* Always run destroy to clean up provisioned services
* Sets name_prefix to cluster name to prevent duplicates
* Adds cluster_config_file_path value from cluster

ibm-garage-cloud/planning#509